### PR TITLE
chore: gnoclient updates from gnomobile for PR #1047

### DIFF
--- a/gno.land/pkg/gnoclient/client_queries.go
+++ b/gno.land/pkg/gnoclient/client_queries.go
@@ -67,9 +67,48 @@ func (c Client) QueryAppVersion() (string, *ctypes.ResultABCIQuery, error) {
 
 	qres, err := c.RPCClient.ABCIQuery(path, data)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "query account")
+		return "", nil, errors.Wrap(err, "query app version")
 	}
 
 	version := string(qres.Response.Value)
 	return version, qres, nil
+}
+
+// Render calls the Render function for pkgPath with optional args. The pkgPath should
+// include the prefix like "gno.land/". This is similar to using a browser URL
+// <testnet>/<pkgPath>:<args> where <pkgPath> doesn't have the prefix like "gno.land/".
+func (c Client) Render(pkgPath string, args string) (string, *ctypes.ResultABCIQuery, error) {
+	if err := c.validateRPCClient(); err != nil {
+		return "", nil, err
+	}
+
+	path := "vm/qrender"
+	data := []byte(fmt.Sprintf("%s\n%s", pkgPath, args))
+
+	qres, err := c.RPCClient.ABCIQuery(path, data)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "query render")
+	}
+
+	return string(qres.Response.Data), qres, nil
+}
+
+// QEval evaluates the given expression with the realm code at pkgPath. The pkgPath should
+// include the prefix like "gno.land/". The expression is usually a function call like
+// "GetBoardIDFromName(\"testboard\")". The return value is a typed expression like
+// "(1 gno.land/r/demo/boards.BoardID)\n(true bool)".
+func (c Client) QEval(pkgPath string, expression string) (string, *ctypes.ResultABCIQuery, error) {
+	if err := c.validateRPCClient(); err != nil {
+		return "", nil, err
+	}
+
+	path := "vm/qeval"
+	data := []byte(fmt.Sprintf("%s\n%s", pkgPath, expression))
+
+	qres, err := c.RPCClient.ABCIQuery(path, data)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "query qeval")
+	}
+
+	return string(qres.Response.Data), qres, nil
 }

--- a/gno.land/pkg/gnoclient/client_txs.go
+++ b/gno.land/pkg/gnoclient/client_txs.go
@@ -86,7 +86,7 @@ func (c Client) signAndBroadcastTxCommit(tx std.Tx, accountNumber, sequenceNumbe
 	caller := c.Signer.Info().GetAddress()
 
 	if sequenceNumber == 0 || accountNumber == 0 {
-		account, _, err := c.QueryAccount(caller.String())
+		account, _, err := c.QueryAccount(caller)
 		if err != nil {
 			return nil, errors.Wrap(err, "query account")
 		}

--- a/gno.land/pkg/gnoclient/signer.go
+++ b/gno.land/pkg/gnoclient/signer.go
@@ -3,6 +3,7 @@ package gnoclient
 import (
 	"fmt"
 
+	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
 	"github.com/gnolang/gno/tm2/pkg/errors"
 	"github.com/gnolang/gno/tm2/pkg/std"
@@ -33,7 +34,20 @@ func (s SignerFromKeybase) Validate() error {
 		return err
 	}
 
-	// TODO: Also verify if the password unlocks the account.
+	// To verify if the password unlocks the account, sign a blank transaction.
+	msg := vm.MsgCall{
+		Caller: s.Info().GetAddress(),
+	}
+	signCfg := SignCfg{
+		UnsignedTX: std.Tx{
+			Msgs: []std.Msg{msg},
+			Fee:  std.NewFee(0, std.NewCoin("ugnot", 1000000)),
+		},
+	}
+	if _, err = s.Sign(signCfg); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
To work on GnoMobile, we made a [copy of gnoclient](https://github.com/gnolang/gnomobile/tree/main/gnoclient) from the PR and made some changes. This is a "PR against the PR" with the changes. It has three commits:
1. In the Client struct, add methods `Render` and `QEval`. Also fix a small copy/paste typo in the error string for QueryAppVersion.
2. The Signer method `Validate` had a comment "TODO: Also verify if the password unlocks the account." This implements to verify if the password unlocks the account by signing a blank transaction. Please see issue https://github.com/gnolang/gno/issues/1324 for more details.
3. As [mentioned in the PR](https://github.com/gnolang/gno/pull/1047#discussion_r1365323435), the type of the `QueryAccount` parameter `addr` should be `crypto.Address` because this is how it is stored in the `keys.Info` struct . This also checks and returns `UnknownAddressError`.