### PR TITLE
fix: use new TransferOwnershipByPrevious method and add tests

### DIFF
--- a/examples/gno.land/r/sys/cla/admin.gno
+++ b/examples/gno.land/r/sys/cla/admin.gno
@@ -26,8 +26,7 @@ func SetCLAURL(cur realm, url string) {
 // TransferOwnership transfers ownership to a new address.
 // Only callable by the current owner.
 func TransferOwnership(cur realm, newOwner address) {
-	owner.AssertOwnedByPrevious()
-	err := owner.TransferOwnership(newOwner)
+	err := owner.TransferOwnershipByPrevious(newOwner)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/gno.land/r/sys/cla/cla_test.gno
+++ b/examples/gno.land/r/sys/cla/cla_test.gno
@@ -5,6 +5,7 @@ import (
 
 	"gno.land/p/moul/addrset"
 	"gno.land/p/nt/ownable"
+	"gno.land/p/nt/testutils"
 	"gno.land/p/nt/uassert"
 )
 
@@ -144,4 +145,33 @@ func TestSetCLAURL_NotOwner(t *testing.T) {
 	})
 
 	uassert.Equal(t, "", claURL)
+}
+
+func TestTransferOwnership_Success(t *testing.T) {
+	resetState()
+
+  // newOwner should be a valid Gno address
+	newOwner := testutils.TestAddress("new-owner")
+	testing.SetRealm(testing.NewUserRealm(ownerAddr))
+
+	uassert.NotPanics(t, func() {
+		TransferOwnership(cross, newOwner)
+	})
+
+	uassert.Equal(t, owner.Owner(), newOwner)
+}
+
+func TestTransferOwnership_NotOwner(t *testing.T) {
+	resetState()
+
+  // newOwner should be a valid Gno address
+	newOwner := testutils.TestAddress("new-owner")
+
+	testing.SetRealm(testing.NewUserRealm(nonOwnerAddr))
+
+	uassert.AbortsWithMessage(t, ownable.ErrUnauthorized.Error(), func() {
+		TransferOwnership(cross, newOwner)
+	})
+
+	uassert.Equal(t, owner.Owner(), address(ownerAddr))
 }

--- a/gno.land/pkg/integration/testdata/addpkg_cla.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_cla.txtar
@@ -97,6 +97,23 @@ stdout 'true bool'
 gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/pkg1 -gas-fee 1000000ugnot -gas-wanted 1000000 -broadcast -chainid=tendermint_test test1
 stdout 'OK!'
 
+# ============================================================
+# Test 6: TransferOwnership behavior
+# ============================================================
+
+# Admin attempts to transfer ownership to alice.
+# Transfer succeeds.
+gnokey maketx call -pkgpath gno.land/r/sys/cla -func TransferOwnership -args "$alice_user_addr" -gas-fee 100000ugnot -gas-wanted 1500000 -broadcast -chainid tendermint_test admin
+stdout 'OK!'
+
+# Previous owner can no longer update settings.
+! gnokey maketx call -pkgpath gno.land/r/sys/cla -func SetCLAURL -args "https://example.com/cla-v1" -gas-fee 100000ugnot -gas-wanted 1500000 -broadcast -chainid tendermint_test admin
+stderr 'caller is not owner'
+
+# New owner (alice) can update settings.
+gnokey maketx call -pkgpath gno.land/r/sys/cla -func SetCLAURL -args "https://example.com/cla-v2" -gas-fee 100000ugnot -gas-wanted 1500000 -broadcast -chainid tendermint_test alice
+stdout 'OK!'
+
 -- gnomod.toml --
 module = "gno.land/r/mypkg"
 gno = "0.9"


### PR DESCRIPTION
This PR updates CLA admin ownership transfer to use the new ownable.TransferOwnershipByPrevious API and adds test coverage across CLA/unit/integration layers.

The CLA realm admin entrypoints are called as cross-realm transactions, where the owner check should be evaluated against runtime.PreviousRealm() (the caller), not runtime.CurrentRealm() (the CLA realm itself).
Using TransferOwnershipByPrevious aligns ownership transfer with existing CLA admin auth semantics (AssertOwnedByPrevious).

This PR depends on https://github.com/gnolang/gno/pull/5147.